### PR TITLE
Added interface support

### DIFF
--- a/Pathoschild.DesignByContract.Analysis/Framework/Analysis/MethodAnalyzer.cs
+++ b/Pathoschild.DesignByContract.Analysis/Framework/Analysis/MethodAnalyzer.cs
@@ -5,204 +5,315 @@ using System.Reflection;
 
 namespace Pathoschild.DesignByContract.Framework.Analysis
 {
-	/// <summary>Reflects methods and properties for contract analysis.</summary>
-	[Serializable]
-	public class MethodAnalyzer : IMethodAnalyzer
-	{
-		/*********
-		** Accessors
-		*********/
-		/// <summary>The singleton instance.</summary>
-		public static MethodAnalyzer Instance = new MethodAnalyzer();
+    /// <summary>Reflects methods and properties for contract analysis.</summary>
+    [Serializable]
+    public class MethodAnalyzer : IMethodAnalyzer
+    {
+        /*********
+        ** Accessors
+        *********/
+        /// <summary>The singleton instance.</summary>
+        public static MethodAnalyzer Instance = new MethodAnalyzer();
 
 
-		/*********
-		** Public methods
-		*********/
-		/// <summary>Analyze the contract annotations on a methods.</summary>
-		/// <param name="method">The method to analyze.</param>
-		/// <param name="inheritContract">Whether to inherit attributes from base types or interfaces.</param>
-		public MethodAnalysis AnalyzeMethod(MethodBase method, bool inheritContract)
-		{
-			// analyze method contract
-			var parameterPreconditions = this.GetParameterPreconditions(method, inheritContract);
-			var returnPreconditions = this.GetReturnValuePreconditions(method, inheritContract);
+        /*********
+        ** Public methods
+        *********/
+        /// <summary>Analyze the contract annotations on a methods.</summary>
+        /// <param name="method">The method to analyze.</param>
+        /// <param name="inheritContract">Whether to inherit attributes from base types or interfaces.</param>
+        public MethodAnalysis AnalyzeMethod(MethodBase method, bool inheritContract)
+        {
+            // analyze method contract
+            var parameterPreconditions = this.GetParameterPreconditions(method, inheritContract);
+            var returnPreconditions = this.GetReturnValuePreconditions(method, inheritContract);
 
-			// analyze property contract
-			PropertyInfo property = this.GetProperty(method);
-			if (property != null)
-			{
-				// cascade annotations on the property to the getter/setter methods
-				if (this.IsPropertyGetter(method))
-					returnPreconditions = returnPreconditions.Union(this.GetReturnValuePreconditions(property, inheritContract));
-				else
-					parameterPreconditions = parameterPreconditions.Union(this.GetParameterPreconditions(property, inheritContract));
-			}
+            // analyze property contract
+            PropertyInfo property = this.GetProperty(method);
+            if (property != null)
+            {
+                // cascade annotations on the property to the getter/setter methods
+                if (this.IsPropertyGetter(method))
+                    returnPreconditions = returnPreconditions.Union(this.GetReturnValuePreconditions(property, inheritContract));
+                else
+                    parameterPreconditions = parameterPreconditions.Union(this.GetParameterPreconditions(property, inheritContract));
+            }
 
-			// return analysis
-			return new MethodAnalysis
-			{
-				ParameterPreconditions = parameterPreconditions.ToArray(),
-				ReturnValuePreconditions = returnPreconditions.ToArray()
-			};
-		}
+            // return analysis
+            return new MethodAnalysis
+            {
+                ParameterPreconditions = parameterPreconditions.ToArray(),
+                ReturnValuePreconditions = returnPreconditions.ToArray()
+            };
+        }
 
 
-		/*********
-		** Protected methods
-		*********/
-		/***
-		** Method analysis
-		***/
-		/// <summary>Get whether a method returns a value.</summary>
-		/// <param name="method">The method to analyze.</param>
-		protected bool HasReturnValue(MethodBase method)
-		{
-			MethodInfo methodInfo = method as MethodInfo;
-			return methodInfo != null && methodInfo.ReturnType != typeof(void);
-		}
+        /*********
+        ** Protected methods
+        *********/
+        /***
+        ** Method analysis
+        ***/
+        /// <summary>Get whether a method returns a value.</summary>
+        /// <param name="method">The method to analyze.</param>
+        protected bool HasReturnValue(MethodBase method)
+        {
+            MethodInfo methodInfo = method as MethodInfo;
+            return methodInfo != null && methodInfo.ReturnType != typeof(void);
+        }
 
-		/// <summary>Get whether a method is a property getter or setter.</summary>
-		/// <param name="method">The method to analyze.</param>
-		protected bool IsPropertyAccessor(MethodBase method)
-		{
-			MethodInfo methodInfo = method as MethodInfo;
-			return methodInfo != null
-				&& methodInfo.IsSpecialName
-				&& (method.Name.StartsWith("get_") || method.Name.StartsWith("set_"));
-		}
+        /// <summary>Get whether a method is a property getter or setter.</summary>
+        /// <param name="method">The method to analyze.</param>
+        protected bool IsPropertyAccessor(MethodBase method)
+        {
+            MethodInfo methodInfo = method as MethodInfo;
+            return methodInfo != null
+                && methodInfo.IsSpecialName
+                && (method.Name.StartsWith("get_") || method.Name.StartsWith("set_"));
+        }
 
-		/// <summary>Get whether the method is a property setter.</summary>
-		/// <param name="method">The method to analyze.</param>
-		protected bool IsPropertyGetter(MethodBase method)
-		{
-			return this.IsPropertyAccessor(method)
-				&& method.Name.StartsWith("get_");
-		}
+        /// <summary>Get whether the method is a property setter.</summary>
+        /// <param name="method">The method to analyze.</param>
+        protected bool IsPropertyGetter(MethodBase method)
+        {
+            return this.IsPropertyAccessor(method)
+                && method.Name.StartsWith("get_");
+        }
 
-		/// <summary>Get the property for which this method is an accessor.</summary>
-		/// <param name="method">The method to analyze.</param>
-		/// <returns>Returns the method's property, or <c>null</c> if it is not an accessor.</returns>
-		protected PropertyInfo GetProperty(MethodBase method)
-		{
-			// analyze method
-			if (!this.IsPropertyAccessor(method) || !(method is MethodInfo))
-				return null;
-			MethodInfo methodInfo = method as MethodInfo;
-			bool isGet = this.IsPropertyGetter(methodInfo);
+        /// <summary>Get the property for which this method is an accessor.</summary>
+        /// <param name="method">The method to analyze.</param>
+        /// <returns>Returns the method's property, or <c>null</c> if it is not an accessor.</returns>
+        protected PropertyInfo GetProperty(MethodBase method)
+        {
+            // analyze method
+            if (!this.IsPropertyAccessor(method) || !(method is MethodInfo))
+                return null;
+            MethodInfo methodInfo = method as MethodInfo;
+            bool isGet = this.IsPropertyGetter(methodInfo);
 
-			// get matching property
-			PropertyInfo[] properties = method.DeclaringType
-				.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static)
-				.Where(p => methodInfo == (isGet ? p.GetGetMethod(true) : p.GetSetMethod(true)))
-				.ToArray();
-			if (properties.Length <= 1)
-				return properties.SingleOrDefault();
+            // get matching property
+            PropertyInfo[] properties = method.DeclaringType
+                .GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static)
+                .Where(p => methodInfo == (isGet ? p.GetGetMethod(true) : p.GetSetMethod(true)))
+                .ToArray();
+            if (properties.Length <= 1)
+                return properties.SingleOrDefault();
 
-			// disambiguate between properties (e.g., hidden properties)
-			PropertyInfo mostDerived = properties.First();
-			foreach (PropertyInfo property in properties)
-			{
-				if (property.DeclaringType.IsSubclassOf(mostDerived.DeclaringType))
-					mostDerived = property;
-			}
-			return mostDerived;
-		}
+            // disambiguate between properties (e.g., hidden properties)
+            PropertyInfo mostDerived = properties.First();
+            foreach (PropertyInfo property in properties)
+            {
+                if (property.DeclaringType.IsSubclassOf(mostDerived.DeclaringType))
+                    mostDerived = property;
+            }
+            return mostDerived;
+        }
 
-		/***
-		** Attributes
-		***/
-		/// <summary>Get the custom attributes of a given type from a provider.</summary>
-		/// <typeparam name="T">The type of the custom attributes.</typeparam>
-		/// <param name="customAttributeProvider">The object from which to retrieve custom attributes.</param>
-		/// <param name="inherit">Whether to inherit attributes from base types or interfaces.</param>
-		protected IEnumerable<T> GetCustomAttributes<T>(ICustomAttributeProvider customAttributeProvider, bool inherit)
-		{
-			return customAttributeProvider.GetCustomAttributes(typeof(T), inherit).Cast<T>();
-		}
+        /***
+        ** Attributes
+        ***/
+        /// <summary>Get the custom attributes of a given type from a provider.</summary>
+        /// <typeparam name="T">The type of the custom attributes.</typeparam>
+        /// <param name="customAttributeProvider">The object from which to retrieve custom attributes.</param>
+        /// <param name="inherit">Whether to inherit attributes from base types or interfaces.</param>
+        protected IEnumerable<T> GetCustomAttributes<T>(ICustomAttributeProvider customAttributeProvider, bool inherit)
+        {
+            return customAttributeProvider.GetCustomAttributes(typeof(T), inherit).Cast<T>();
+        }
 
-		/// <summary>Get the custom attributes of a given type from a provider.</summary>
-		/// <typeparam name="T">The type of the custom attributes.</typeparam>
-		/// <param name="property">The object from which to retrieve custom attributes.</param>
-		/// <param name="inherit">Whether to inherit attributes from base types or interfaces.</param>
-		protected IEnumerable<T> GetCustomAttributes<T>(MemberInfo property, bool inherit)
-		{
-			return property.GetCustomAttributes(typeof(T), inherit).Cast<T>();
-		}
+        /// <summary>Get the custom attributes of a given type from a provider.</summary>
+        /// <typeparam name="T">The type of the custom attributes.</typeparam>
+        /// <param name="property">The object from which to retrieve custom attributes.</param>
+        /// <param name="inherit">Whether to inherit attributes from base types or interfaces.</param>
+        protected IEnumerable<T> GetCustomAttributes<T>(MemberInfo property, bool inherit)
+        {
+            return property.GetCustomAttributes(typeof(T), inherit).Cast<T>();
+        }
 
-		/// <summary>Get the attributes applied to a method.</summary>
-		/// <typeparam name="T">The attribute type to get.</typeparam>
-		/// <param name="method">The method whose attributes to get.</param>
-		/// <param name="inherit">Whether to inherit attributes from base types or interfaces.</param>
-		/// <param name="withReturnTypeAttributes">Whether to include attributes restricted to its return type.</param>
-		protected IEnumerable<T> GetMethodAttributes<T>(MethodInfo method, bool inherit, bool withReturnTypeAttributes = false)
-		{
-			var attributes = this.GetCustomAttributes<T>(method, inherit);
-			if (withReturnTypeAttributes)
-				attributes = attributes.Union(this.GetCustomAttributes<T>(method.ReturnTypeCustomAttributes, inherit));
-			return attributes;
-		}
+        /// <summary>Get the attributes applied to a method.</summary>
+        /// <typeparam name="T">The attribute type to get.</typeparam>
+        /// <param name="method">The method whose attributes to get.</param>
+        /// <param name="inherit">Whether to inherit attributes from base types or interfaces.</param>
+        /// <param name="withReturnTypeAttributes">Whether to include attributes restricted to its return type.</param>
+        protected IEnumerable<T> GetMethodAttributes<T>(MethodInfo method, bool inherit, bool withReturnTypeAttributes = false)
+        {
+            var attributes = this.GetCustomAttributes<T>(method, inherit);
+            if (withReturnTypeAttributes)
+                attributes = attributes.Union(this.GetCustomAttributes<T>(method.ReturnTypeCustomAttributes, inherit));
 
-		/// <summary>Get the attributes applied to a parameter.</summary>
-		/// <typeparam name="T">The attribute type to get.</typeparam>
-		/// <param name="parameter">The parameter whose attributes to get.</param>
-		/// <param name="inherit">Whether to inherit attributes from base types or interfaces.</param>
-		protected IEnumerable<T> GetParameterAttributes<T>(ParameterInfo parameter, bool inherit)
-		{
-			return this.GetCustomAttributes<T>(parameter, inherit);
-		}
+            return attributes;
+        }
 
-		/***
-		** Preconditions
-		***/
-		/// <summary>Get the contract requirements for each method parameter or property setter value.</summary>
-		/// <param name="method">The method to analyze.</param>
-		/// <param name="inherit">Whether to inherit attributes from base types or interfaces.</param>
-		protected IEnumerable<ParameterMetadata> GetParameterPreconditions(MethodBase method, bool inherit)
-		{
-			return (
-				from parameter in method.GetParameters()
-				from IParameterPrecondition annotation in this.GetParameterAttributes<IParameterPrecondition>(parameter, inherit)
-				select new ParameterMetadata(parameter, annotation)
-			);
-		}
+        /// <summary>Get the attributes applied to a parameter.</summary>
+        /// <typeparam name="T">The attribute type to get.</typeparam>
+        /// <param name="parameter">The parameter whose attributes to get.</param>
+        /// <param name="inherit">Whether to inherit attributes from base types or interfaces.</param>
+        protected IEnumerable<T> GetParameterAttributes<T>(ParameterInfo parameter, bool inherit)
+        {
+            return this.GetCustomAttributes<T>(parameter, inherit);
+        }
 
-		/// <summary>Get the contract requirements for the property setter value.</summary>
-		/// <param name="property">The property to analyze.</param>
-		/// <param name="inherit">Whether to inherit attributes from base types or interfaces.</param>
-		protected IEnumerable<ParameterMetadata> GetParameterPreconditions(PropertyInfo property, bool inherit)
-		{
-			if (!property.CanWrite)
-				return new ParameterMetadata[0];
+        /***
+        ** Preconditions
+        ***/
+        /// <summary>Get the contract requirements for each method parameter or property setter value.</summary>
+        /// <param name="method">The method to analyze.</param>
+        /// <param name="inherit">Whether to inherit attributes from base types or interfaces.</param>
+        protected IEnumerable<ParameterMetadata> GetParameterPreconditions(MethodBase method, bool inherit)
+        {
+            // would have been a bit cleaner to do this in GetCustomAttributes but it'll be
+            // more performant to run this once per method vs once per method param
+            var interfaceMethod = GetInterfaceDefinition(method) as MethodInfo;
+            if (interfaceMethod != null)
+            {
+                var interfaceParameters = interfaceMethod.GetParameters();
+                var methodParameters = method.GetParameters();
 
-			ParameterInfo parameter = property.GetSetMethod(true).GetParameters().Last(); // setter value (implicit last parameter)
-			return (
-				from annotation in this.GetCustomAttributes<IParameterPrecondition>(property, inherit)
-				select new ParameterMetadata(parameter, annotation, property.Name)
-			);
-		}
+                // in the case that both the interface and the implementation define an attribute, 
+                // we assume that the implementation has defined only complementary attributes so we include
+                // them all. this is a valid use case when the attributes contain parameters - the implementation
+                // may define further restrictions
 
-		/// <summary>Get the contract requirements on a method or property return value.</summary>
-		/// <param name="method">The method to analyze.</param>
-		/// <param name="inherit">Whether to inherit attributes from base types or interfaces.</param>
-		protected IEnumerable<ReturnValueMetadata> GetReturnValuePreconditions(MethodBase method, bool inherit)
-		{
-			if (!this.HasReturnValue(method))
-				return new ReturnValueMetadata[0];
+                return methodParameters.SelectMany(parameter =>
+                {
+                    var interfaceParam = interfaceParameters.Single(p => p.Position == parameter.Position);
+                    return GetAnnotations(parameter, true).Union(GetAnnotations(interfaceParam, false));
+                });
+            }
 
-			return this
-				.GetMethodAttributes<IReturnValuePrecondition>(method as MethodInfo, inherit, true)
-				.Select(attr => new ReturnValueMetadata(method, attr));
-		}
+            return method.GetParameters().SelectMany(parameter => GetAnnotations(parameter, inherit));
+        }
 
-		/// <summary>Get the contract requirements on a method or property return value.</summary>
-		/// <param name="property">The method to analyze.</param>
-		/// <param name="inherit">Whether to inherit attributes from base types or interfaces.</param>
-		protected IEnumerable<ReturnValueMetadata> GetReturnValuePreconditions(PropertyInfo property, bool inherit)
-		{
-			return this
-				.GetCustomAttributes<IReturnValuePrecondition>(property, inherit)
-				.Select(attr => new ReturnValueMetadata(property, attr));
-		}
-	}
+        
+
+        /// <summary>Get the contract requirements for the property setter value.</summary>
+        /// <param name="property">The property to analyze.</param>
+        /// <param name="inherit">Whether to inherit attributes from base types or interfaces.</param>
+        protected IEnumerable<ParameterMetadata> GetParameterPreconditions(PropertyInfo property, bool inherit)
+        {
+            if (!property.CanWrite)
+                return new ParameterMetadata[0];                   
+
+            var interfaceProperty = GetInterfaceDefinition(property) as PropertyInfo;
+            if(interfaceProperty != null)
+            {
+                return GetAnnotations(interfaceProperty, false)
+                    .Union(GetAnnotations(property, inherit));
+            }
+
+            return GetAnnotations(property, inherit);
+        }
+
+        /// <summary>Get the contract requirements on a method or property return value.</summary>
+        /// <param name="method">The method to analyze.</param>
+        /// <param name="inherit">Whether to inherit attributes from base types or interfaces.</param>
+        protected IEnumerable<ReturnValueMetadata> GetReturnValuePreconditions(MethodBase method, bool inherit)
+        {
+            if (!this.HasReturnValue(method))
+                return new ReturnValueMetadata[0];
+
+            MethodInfo interfaceMethod = GetInterfaceDefinition(method) as MethodInfo;
+            if (inherit && interfaceMethod != null)
+            {
+                var methodAttributes = GetMethodAttributes<IReturnValuePrecondition>(method as MethodInfo, true, true);
+                var interfaceAttributes = GetMethodAttributes<IReturnValuePrecondition>(interfaceMethod, false, true);
+                return methodAttributes.Union(interfaceAttributes)
+                    .Select(annotation => new ReturnValueMetadata(interfaceMethod, annotation));
+            }
+
+            return this
+                .GetMethodAttributes<IReturnValuePrecondition>(method as MethodInfo, inherit, true)
+                .Select(attr => new ReturnValueMetadata(method, attr));
+        }
+
+        /// <summary>Get the contract requirements on a method or property return value.</summary>
+        /// <param name="property">The method to analyze.</param>
+        /// <param name="inherit">Whether to inherit attributes from base types or interfaces.</param>
+        protected IEnumerable<ReturnValueMetadata> GetReturnValuePreconditions(PropertyInfo property, bool inherit)
+        {
+            var interfaceMethod = GetInterfaceDefinition(property);
+            if (inherit && interfaceMethod != null)
+            {
+                var methodAttributes = GetCustomAttributes<IReturnValuePrecondition>(property, true);
+                var interfaceAttributes = GetCustomAttributes<IReturnValuePrecondition>(interfaceMethod, false);
+                return methodAttributes.Union(interfaceAttributes)
+                    .Select(annotation => new ReturnValueMetadata(interfaceMethod, annotation));
+            }
+
+            return this
+                .GetCustomAttributes<IReturnValuePrecondition>(property, inherit)
+                .Select(attr => new ReturnValueMetadata(property, attr));
+        }
+
+        private IEnumerable<ParameterMetadata> GetAnnotations(ParameterInfo parameter, bool inherit)
+        {
+            return GetParameterAttributes<IParameterPrecondition>(parameter, inherit)
+                .Select(annotation => new ParameterMetadata(parameter, annotation));
+        }
+
+        private IEnumerable<ParameterMetadata> GetAnnotations(PropertyInfo property, bool inherit)
+        {
+            return GetCustomAttributes<IParameterPrecondition>(property, inherit)
+                .Select(annotation =>
+                {
+                    // setter value (implicit last parameter)
+                    ParameterInfo parameter = property.GetSetMethod(true).GetParameters().Last();
+                    return new ParameterMetadata(parameter, annotation, property.Name);
+                });
+        }
+
+        private MemberInfo GetInterfaceDefinition(MemberInfo info)
+        {
+            Type methodType = info.ReflectedType;
+            return methodType.GetInterfaces()
+                .SelectMany(iface => methodType.GetInterfaceMap(iface).InterfaceMethods)
+                .Where(m => MemberSignatureEquals(m, info))
+                .Select(m =>
+                {
+                    // if it's a prop getter/setter, return the property itself
+                    if (IsPropertyAccessor(m))
+                        return (MemberInfo)GetProperty(m);
+                    return m;
+                })
+                .Distinct()
+                .SingleOrDefault();
+        }
+
+        private bool MemberSignatureEquals(MemberInfo m1, MemberInfo m2)
+        {
+            Func<ParameterInfo, Type> selectParameterType = p => p.ParameterType;
+            Func<MemberInfo, string> nameOf = mi => mi is MethodBase && IsPropertyAccessor(mi as MethodBase)
+                ? GetProperty(mi as MethodBase).Name
+                : mi.Name;
+
+            string name1 = nameOf(m1);
+            string name2 = nameOf(m2);
+
+            return name1 == name2
+                // ctors
+                   && SelectivelyEquals<MethodBase>(m => m.GetParameters().Select(selectParameterType), m1, m2)
+                // methods
+                   && SelectivelyEquals<MethodInfo>(m => m.ReturnType, m1, m2)
+                // fields
+                   && SelectivelyEquals<FieldInfo>(f => f.FieldType, m1, m2)
+                // properties
+                   && SelectivelyEquals<PropertyInfo>(p => p.PropertyType, m1, m2);
+        }
+
+        private static bool SelectivelyEquals<T>(Func<T, IEnumerable<Type>> select, MemberInfo o1, MemberInfo o2)
+            where T : class
+        {
+            if (!(o1 is T) || !(o2 is T))
+                return true;
+            return select(o1 as T).SequenceEqual(select(o2 as T));
+        }
+
+        private static bool SelectivelyEquals<T>(Func<T, Type> select, MemberInfo o1, MemberInfo o2)
+            where T : class
+        {
+            if (!(o1 is T) || !(o2 is T))
+                return true;
+            return select(o1 as T) == select(o2 as T);
+        }
+    }
 }

--- a/Pathoschild.DesignByContract.Analysis/JsonNetAspectSerializer.cs
+++ b/Pathoschild.DesignByContract.Analysis/JsonNetAspectSerializer.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using Newtonsoft.Json;
 using PostSharp.Aspects;
 using PostSharp.Aspects.Serialization;
@@ -25,6 +26,7 @@ namespace Pathoschild.DesignByContract
 		/// <summary>Serialize a set of aspects.</summary>
 		/// <param name="aspects">The aspects to serialize.</param>
 		/// <param name="stream">The stream to which to write.</param>
+		[Obsolete]
 		public override void Serialize(IAspect[] aspects, Stream stream)
 		{
 			using (StreamWriter writer = new StreamWriter(stream))
@@ -36,6 +38,7 @@ namespace Pathoschild.DesignByContract
 
 		/// <summary>Deserialize a set of aspects.</summary>
 		/// <param name="stream">The stream from which to read.</param>
+		[Obsolete]
 		public override IAspect[] Deserialize(Stream stream)
 		{
 			using (StreamReader reader = new StreamReader(stream))

--- a/Pathoschild.DesignByContract.Annotations/NotDefaultAttribute.cs
+++ b/Pathoschild.DesignByContract.Annotations/NotDefaultAttribute.cs
@@ -1,0 +1,41 @@
+using System;
+using Pathoschild.DesignByContract.Framework;
+
+namespace Pathoschild.DesignByContract
+{
+    /// <summary>A contract precondition that a value is not equal to <c>default(Type)</c>.</summary>
+    [AttributeUsage((AttributeTargets)(ConditionTargets.Parameter | ConditionTargets.ReturnValue))]
+    [Serializable]
+    public class NotDefaultAttribute : Attribute, IParameterPrecondition, IReturnValuePrecondition
+    {
+        /*********
+        ** Public methods
+        *********/
+        /// <summary>Validate the requirement on a single method parameter or property setter value.</summary>
+        /// <param name="parameter">The parameter metadata.</param>
+        /// <param name="value">The parameter value.</param>
+        /// <exception cref="ParameterContractException">The contract requirement was not met.</exception>
+        public void OnParameterPrecondition(ParameterMetadata parameter, object value)
+        {
+            if (value == null || value.Equals(GetDefaultValue(value.GetType())))
+                throw new ParameterContractException(parameter, "cannot have default value");
+        }
+
+        /// <summary>Validate the requirement on a method or property return value.</summary>
+        /// <param name="returnValue">The return value metadata.</param>
+        /// <param name="value">The return value.</param>
+        /// <exception cref="ReturnValueContractException">The contract requirement was not met.</exception>
+        public void OnReturnValuePrecondition(ReturnValueMetadata returnValue, object value)
+        {
+            if (value == null || value.Equals(GetDefaultValue(value.GetType())))
+                throw new ReturnValueContractException(returnValue, "cannot have default value");
+        }
+
+        private static object GetDefaultValue(Type t)
+        {
+            if (t.IsValueType)
+                return Activator.CreateInstance(t);
+            return null;
+        }
+    }
+}

--- a/Pathoschild.DesignByContract.Annotations/NotDefaultAttribute.cs
+++ b/Pathoschild.DesignByContract.Annotations/NotDefaultAttribute.cs
@@ -17,7 +17,7 @@ namespace Pathoschild.DesignByContract
         /// <exception cref="ParameterContractException">The contract requirement was not met.</exception>
         public void OnParameterPrecondition(ParameterMetadata parameter, object value)
         {
-            if (value == null || value.Equals(GetDefaultValue(value.GetType())))
+            if (value == null || IsDefaultValue(value))
                 throw new ParameterContractException(parameter, "cannot have default value");
         }
 
@@ -27,8 +27,14 @@ namespace Pathoschild.DesignByContract
         /// <exception cref="ReturnValueContractException">The contract requirement was not met.</exception>
         public void OnReturnValuePrecondition(ReturnValueMetadata returnValue, object value)
         {
-            if (value == null || value.Equals(GetDefaultValue(value.GetType())))
+            if (value == null || IsDefaultValue(value))
                 throw new ReturnValueContractException(returnValue, "cannot have default value");
+        }
+
+        private static bool IsDefaultValue(object value)
+        {
+            Type valueType = value.GetType();
+            return value.Equals(GetDefaultValue(valueType));
         }
 
         private static object GetDefaultValue(Type t)

--- a/Pathoschild.DesignByContract.Annotations/Pathoschild.DesignByContract.Annotations.csproj
+++ b/Pathoschild.DesignByContract.Annotations/Pathoschild.DesignByContract.Annotations.csproj
@@ -45,6 +45,7 @@
     <Compile Include="Framework\ReturnValueMetadata.cs" />
     <Compile Include="HasTypeAttribute.cs" />
     <Compile Include="NotBlankAttribute.cs" />
+    <Compile Include="NotDefaultAttribute.cs" />
     <Compile Include="NotEmptyAttribute.cs" />
     <Compile Include="Framework\IParameterPrecondition.cs" />
     <Compile Include="Framework\IReturnValuePrecondition.cs" />

--- a/Pathoschild.DesignByContract.Tests/Attributes/NotDefault.cs
+++ b/Pathoschild.DesignByContract.Tests/Attributes/NotDefault.cs
@@ -23,5 +23,22 @@ namespace Pathoschild.DesignByContract.Tests.Attributes
         {
             return value;
         }
+
+        [ParameterContractTestCase(5, false)]
+        [ParameterContractTestCase(0, true)]
+        [ParameterContractTestCase(null, true)]
+        public int? OnNullableParameter([NotDefault] int? value)
+        {
+            return value;
+        }
+
+        [ReturnValueContractTestCase(5, false)]
+        [ReturnValueContractTestCase(0, true)]
+        [ReturnValueContractTestCase(null, true)]
+        [return: NotDefault]
+        public int? OnNullableReturnValue(int? value)
+        {
+            return value;
+        }
     }
 }

--- a/Pathoschild.DesignByContract.Tests/Attributes/NotDefault.cs
+++ b/Pathoschild.DesignByContract.Tests/Attributes/NotDefault.cs
@@ -1,0 +1,27 @@
+﻿using NUnit.Framework;
+using Pathoschild.DesignByContract.Tests.Framework;
+
+namespace Pathoschild.DesignByContract.Tests.Attributes
+{
+    /// <summary>Unit tests for <see cref="NotNullAttribute"/>.</summary>
+    /// <remarks>These tests assume that the <see cref="DesignedByContractTests"/> pass.</remarks>
+    [TestFixture]
+    [DesignedByContract]
+    public class NotDefaultTests
+    {
+        [ParameterContractTestCase(5, false)]
+        [ParameterContractTestCase(0, true)]
+        public int OnParameter([NotDefault] int value)
+        {
+            return value;
+        }
+
+        [ReturnValueContractTestCase(5, false)]
+        [ReturnValueContractTestCase(0, true)]
+        [return: NotDefault]
+        public int OnReturnValue(int value)
+        {
+            return value;
+        }
+    }
+}

--- a/Pathoschild.DesignByContract.Tests/Framework/DesignedByContractTests.cs
+++ b/Pathoschild.DesignByContract.Tests/Framework/DesignedByContractTests.cs
@@ -86,32 +86,26 @@ namespace Pathoschild.DesignByContract.Tests.Framework
 		/***
 		** Methods (interface)
 		***/
-		[TestParameterAnnotationCase(true, "Sword", "OnMethodParameter")]
-		[TestParameterAnnotationCase(false, "Sword", "OnMethodParameter")]
+		[TestParameterAnnotationCase(true, "ISword", "OnMethodParameter")]
+		[TestParameterAnnotationCase(false, "ISword", "OnMethodParameter")]
 		public bool OnInterface_MethodParameter(bool value)
 		{
-			Assert.Inconclusive("Interface support is not yet implemented.");
-
 			ISword sword = new InterfaceSword();
 			return sword.OnMethodParameter(value);
 		}
 
-		[TestReturnValueAnnotationCase(true, "Sword", "OnMethodReturnValue")]
-		[TestReturnValueAnnotationCase(false, "Sword", "OnMethodReturnValue")]
+		[TestReturnValueAnnotationCase(true, "ISword", "OnMethodReturnValue")]
+		[TestReturnValueAnnotationCase(false, "ISword", "OnMethodReturnValue")]
 		public bool OnInterface_MethodReturnValue(bool value)
 		{
-			Assert.Inconclusive("Interface support is not yet implemented.");
-
 			ISword sword = new InterfaceSword();
 			return sword.OnMethodReturnValue(value);
 		}
 
-		[TestReturnValueAnnotationCase(true, "Sword", "OnMethod")]
-		[TestReturnValueAnnotationCase(false, "Sword", "OnMethod")]
+		[TestReturnValueAnnotationCase(true, "ISword", "OnMethod")]
+		[TestReturnValueAnnotationCase(false, "ISword", "OnMethod")]
 		public bool OnInterface_Method(bool value)
 		{
-			Assert.Inconclusive("Interface support is not yet implemented.");
-
 			ISword sword = new InterfaceSword();
 			return sword.OnMethod(value);
 		}
@@ -202,67 +196,45 @@ namespace Pathoschild.DesignByContract.Tests.Framework
 		/***
 		** Properties (interfaces)
 		***/
-		[TestReturnValueAnnotationCase(true, "InterfaceSword", "OnProperty")]
-		[TestReturnValueAnnotationCase(false, "InterfaceSword", "OnProperty")]
+		[TestReturnValueAnnotationCase(true, "ISword", "OnProperty")]
+		[TestReturnValueAnnotationCase(false, "ISword", "OnProperty")]
 		public bool OnInterface_Property_Get(bool value)
 		{
-			Assert.Inconclusive("Interface support is not yet implemented.");
 			return new InterfaceSword { _onProperty = value }.OnProperty;
 		}
 
-		[TestReturnValueAnnotationCase(true, "InterfaceSword", "PrivateProperty")]
-		[TestReturnValueAnnotationCase(false, "InterfaceSword", "PrivateProperty")]
-		public bool OnInterface_Property_GetPrivate(bool value)
-		{
-			Assert.Inconclusive("Interface support is not yet implemented.");
-			return new InterfaceSword { _privateProperty = value }.OnPrivateProperty;
-		}
-
-		[TestReturnValueAnnotationCase(true, "InterfaceSword", "OnReadonlyProperty")]
-		[TestReturnValueAnnotationCase(false, "InterfaceSword", "OnReadonlyProperty")]
+		[TestReturnValueAnnotationCase(true, "ISword", "OnReadonlyProperty")]
+		[TestReturnValueAnnotationCase(false, "ISword", "OnReadonlyProperty")]
 		public bool OnInterface_Property_GetReadonly(bool value)
 		{
-			Assert.Inconclusive("Interface support is not yet implemented.");
 			return new InterfaceSword { _onReadonlyProperty = value }.OnReadonlyProperty;
 		}
 
-		[TestReturnValueAnnotationCase(true, "InterfaceSword", "Item")]
-		[TestReturnValueAnnotationCase(false, "InterfaceSword", "Item")]
+		[TestReturnValueAnnotationCase(true, "ISword", "Item")]
+		[TestReturnValueAnnotationCase(false, "ISword", "Item")]
 		public bool OnInterface_Property_GetIndexer(bool value)
 		{
-			Assert.Inconclusive("Interface support is not yet implemented.");
 			return new InterfaceSword { _onIndexer = value }[value];
 		}
 
-		[TestParameterAnnotationCase(true, "InterfaceSword", "OnProperty")]
-		[TestParameterAnnotationCase(false, "InterfaceSword", "OnProperty")]
+        [TestParameterAnnotationCase(true, "ISword", "OnProperty")]
+        [TestParameterAnnotationCase(false, "ISword", "OnProperty")]
 		public bool OnInterface_Property_Set(bool value)
 		{
-			Assert.Inconclusive("Interface support is not yet implemented.");
 			return new InterfaceSword().OnProperty = value;
 		}
 
-		[TestParameterAnnotationCase(true, "InterfaceSword", "PrivateProperty")]
-		[TestParameterAnnotationCase(false, "InterfaceSword", "PrivateProperty")]
-		public bool OnInterface_Property_SetPrivate(bool value)
-		{
-			Assert.Inconclusive("Interface support is not yet implemented.");
-			return new InterfaceSword().OnPrivateProperty = value;
-		}
-
-		[TestParameterAnnotationCase(true, "InterfaceSword", "OnWriteonlyProperty")]
-		[TestParameterAnnotationCase(false, "InterfaceSword", "OnWriteonlyProperty")]
+        [TestParameterAnnotationCase(true, "ISword", "OnWriteonlyProperty")]
+        [TestParameterAnnotationCase(false, "ISword", "OnWriteonlyProperty")]
 		public bool OnInterface_Property_SetWriteonly(bool value)
 		{
-			Assert.Inconclusive("Interface support is not yet implemented.");
 			return new InterfaceSword().OnWriteonlyProperty = value;
 		}
 
-		[TestReturnValueAnnotationCase(true, "InterfaceSword", "Item")]
-		[TestReturnValueAnnotationCase(false, "InterfaceSword", "Item")]
+        [TestParameterAnnotationCase(true, "ISword", "Item")]
+        [TestParameterAnnotationCase(false, "ISword", "Item")]
 		public bool OnInterface_Property_SetIndexer(bool value)
 		{
-			Assert.Inconclusive("Interface support is not yet implemented.");
 			return new InterfaceSword()[value] = value;
 		}
 

--- a/Pathoschild.DesignByContract.Tests/Pathoschild.DesignByContract.Tests.csproj
+++ b/Pathoschild.DesignByContract.Tests/Pathoschild.DesignByContract.Tests.csproj
@@ -44,6 +44,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Attributes\HasType.cs" />
+    <Compile Include="Attributes\NotDefault.cs" />
     <Compile Include="Attributes\NotEmpty.cs" />
     <Compile Include="Attributes\NotBlank.cs" />
     <Compile Include="Attributes\NotNull.cs" />


### PR DESCRIPTION
I've extended your analyzer to scan for interface implementations and draw attributes from there too.
Attributes are merged such that the implementation of the interface can add extra attributes and they will be picked up.
I've made sure all tests pass but I didn't go to the added trouble of testing the above "merging" of attributes between interface + implementation.

Also, it would be nice if you could just add [DesignedByContract] to the interface only and have it picked up by the implementation(s). Not sure if this is possible from the Post# API.

Anyway, let me know what you think.
